### PR TITLE
feat: add express backend api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+server/.env

--- a/main.js
+++ b/main.js
@@ -1,71 +1,66 @@
 /***********************
- * PsicoSST Cloud – Core
- * Estado demo en LocalStorage (sin backend)
+ * PsicoSST Cloud – Front conectado a API
  ***********************/
+const API_BASE = location.origin; // mismo host/puerto del server Express
+const $ = (s, c=document)=>c.querySelector(s);
+const $$ = (s, c=document)=>[...c.querySelectorAll(s)];
+const fmt = x => (x==null?'':String(x));
 
-/* ---------------------
-   Utilidades básicas
-----------------------*/
-const $ = (sel, ctx = document) => ctx.querySelector(sel);
-const $$ = (sel, ctx = document) => [...ctx.querySelectorAll(sel)];
-const fmt = (x) => (x == null ? "" : String(x));
-
-/* ---------------------
-   Store (LocalStorage)
-----------------------*/
-const STORE_KEY = "psicosst_demo_v1";
-
-const Seed = {
-  empresa: { nombre: "AlbatrossCloud SAC", ruc: "2060XXXXXXX", instrumento: "MINSA 2024", firmaPsicologo: "Lic. Armando Aparicio – C.Ps.P XXXXX – Habilitado" },
-  evaluaciones: [
-    { id: crypto.randomUUID(), instrumento: "MINSA 2024", area: "Atención al Cliente", periodo: "2025-10", estado: "En curso", respuestas: 36, total: 50 },
-    { id: crypto.randomUUID(), instrumento: "COPSOQ",      area: "Ventas",              periodo: "2025-09", estado: "Completado", respuestas: 42, total: 45 },
-    { id: crypto.randomUUID(), instrumento: "MINSA 2024",  area: "Operaciones",         periodo: "2025-08", estado: "Completado", respuestas: 50, total: 50 },
-  ],
-  casos: [
-    { id: "CASE-0012", tipo: "Acoso",      prioridad: "Alta",   updatedAt: "2025-10-02" },
-    { id: "CASE-0013", tipo: "Conflicto",  prioridad: "Media",  updatedAt: "2025-10-03" },
-  ],
-  acciones: [
-    { id: crypto.randomUUID(), riesgo: "Carga mental alta", accion: "Redistribuir turnos y pausas", responsable: "Jefe Operaciones", vence: "2025-10-20", estado: "En curso" },
-    { id: crypto.randomUUID(), riesgo: "Liderazgo deficiente", accion: "Taller de feedback efectivo", responsable: "RRHH", vence: "2025-11-05", estado: "Pendiente" },
-  ]
-};
-
-const Store = {
-  _data: null,
-  load() {
-    const raw = localStorage.getItem(STORE_KEY);
-    if (raw) {
-      try { this._data = JSON.parse(raw); }
-      catch { this._data = structuredClone(Seed); }
-    } else {
-      this._data = structuredClone(Seed);
-      this.save();
-    }
-    return this._data;
+/* -------- Cliente API -------- */
+const Api = {
+  async kpis() {
+    const r = await fetch(`${API_BASE}/api/kpis`);
+    if (!r.ok) throw new Error('KPIs');
+    return r.json();
   },
-  save() { localStorage.setItem(STORE_KEY, JSON.stringify(this._data)); },
-  get() { return this._data || this.load(); },
-
-  // CRUD evaluaciones
-  eval_list() { return this.get().evaluaciones; },
-  eval_add(e) { this.get().evaluaciones.unshift({ id: crypto.randomUUID(), respuestas: 0, total: 0, estado: "En curso", ...e }); this.save(); },
-  eval_update(id, patch) {
-    const arr = this.get().evaluaciones;
-    const i = arr.findIndex(x => x.id === id);
-    if (i >= 0) { arr[i] = { ...arr[i], ...patch }; this.save(); }
+  async evaluaciones_list() {
+    const r = await fetch(`${API_BASE}/api/evaluaciones`);
+    if (!r.ok) throw new Error('Evaluaciones');
+    return r.json();
   },
-  eval_remove(id) {
-    const arr = this.get().evaluaciones;
-    const i = arr.findIndex(x => x.id === id);
-    if (i >= 0) { arr.splice(i,1); this.save(); }
+  async evaluaciones_create({ tenant_id, instrumento, area, periodo, total_trab }) {
+    const r = await fetch(`${API_BASE}/api/evaluaciones`, {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ tenant_id, instrumento, area, periodo, total_trab })
+    });
+    if (!r.ok) throw new Error('Crear evaluación');
+    return r.json();
+  },
+  async evaluaciones_finalizar(id) {
+    const r = await fetch(`${API_BASE}/api/evaluaciones/${id}/finalizar`, { method:'PUT' });
+    if (!r.ok) throw new Error('Finalizar evaluación');
+    return r.json();
+  },
+  async evaluaciones_delete(id) {
+    const r = await fetch(`${API_BASE}/api/evaluaciones/${id}`, { method:'DELETE' });
+    if (!r.ok) throw new Error('Eliminar evaluación');
+    return r.json();
+  },
+  async acciones_list() {
+    const r = await fetch(`${API_BASE}/api/acciones`);
+    if (!r.ok) throw new Error('Acciones');
+    return r.json();
+  },
+  async acciones_create(payload) {
+    const r = await fetch(`${API_BASE}/api/acciones`, {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(payload)
+    });
+    if (!r.ok) throw new Error('Crear acción');
+    return r.json();
+  },
+  async acciones_update(id, payload) {
+    const r = await fetch(`${API_BASE}/api/acciones/${id}`, {
+      method:'PUT', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(payload)
+    });
+    if (!r.ok) throw new Error('Actualizar acción');
+    return r.json();
   }
 };
 
-/* ---------------------
-   Router por hash
-----------------------*/
+/* -------- Router por hash -------- */
 const routes = {
   '': 'views/dashboard.html',
   '#/dashboard': 'views/dashboard.html',
@@ -78,69 +73,62 @@ const routes = {
   '#/usuarios': 'views/usuarios.html',
   '#/config': 'views/config.html',
 };
-
 const viewContainer = document.getElementById('view-container');
 const menu = document.getElementById('menu');
 const crumb = document.getElementById('crumb');
 
+/* -------- Carga de vistas -------- */
 async function loadView() {
   const hash = window.location.hash || '#/dashboard';
   const path = routes[hash] || routes['#/dashboard'];
 
-  // activa item menú
-  $$(".menu .item").forEach(a => a.classList.toggle('active', a.getAttribute('href') === hash));
-
-  // migas
+  $$('.menu .item').forEach(a => a.classList.toggle('active', a.getAttribute('href') === hash));
   const current = (menu.querySelector(`a[href="${hash}"]`)?.textContent || 'Dashboard').replace(/\s*\d*\s*pendientes/,'').trim();
   crumb.textContent = current;
 
   try {
-    const res = await fetch(path, { cache: 'no-cache' });
+    const res = await fetch(path, { cache:'no-cache' });
     const html = await res.text();
     viewContainer.innerHTML = html;
-    initPerView(hash);
+    await initPerView(hash);
   } catch (err) {
+    console.error(err);
     viewContainer.innerHTML = `<div class="card"><h3>Error</h3><p class="muted">No se pudo cargar la vista: ${path}</p></div>`;
   }
 }
 
-/* ---------------------
-   Controladores de vista
-----------------------*/
-function initPerView(hash) {
-  const data = Store.get();
-
+/* -------- Controladores por vista -------- */
+async function initPerView(hash) {
   // DASHBOARD
   if (hash === '#/dashboard' || hash === '') {
-    const totResp = data.evaluaciones.reduce((a,b)=> a + (b.respuestas||0), 0);
-    const totCapacidad = data.evaluaciones.reduce((a,b)=> a + (b.total||0), 0) || 1;
-    const tasa = Math.round((totResp / totCapacidad) * 100);
-
-    $("#kpi-respondidas") && ($("#kpi-respondidas").textContent = fmt(totResp));
-    $("#kpi-tasa") && ($("#kpi-tasa").textContent = `${tasa}% tasa`);
-
-    // Riesgo global (demo): si hay alguna evaluación "Completado" con total>0 y respuestas<total => “Medio”
-    const hayAlto = data.casos.some(c => c.prioridad === "Alta");
-    $("#kpi-riesgo") && ($("#kpi-riesgo").textContent = hayAlto ? "Medio" : "Bajo");
-    $("#kpi-riesgo-pill") && ($("#kpi-riesgo-pill").className = "pill " + (hayAlto ? "warn" : "ok"));
-
-    const casosAbiertos = data.casos.length;
-    $("#kpi-casos") && ($("#kpi-casos").textContent = fmt(casosAbiertos));
-    $("#kpi-casos-pill") && ($("#kpi-casos-pill").textContent = casosAbiertos >= 3 ? "3 urgentes" : "OK");
-    $("#kpi-casos-pill") && ($("#kpi-casos-pill").className = "pill " + (casosAbiertos >= 3 ? "danger" : "ok"));
+    try {
+      const kpis = await Api.kpis();
+      // si tienes multi-tenant, elige el primero por ahora:
+      const k = kpis[0] || { total_respondido:0, total_programado:0, tasa_participacion_pct:0, casos_abiertos:0, riesgo_global_aprox:'Bajo' };
+      $('#kpi-respondidas') && ($('#kpi-respondidas').textContent = fmt(k.total_respondido));
+      $('#kpi-tasa') && ($('#kpi-tasa').textContent = `${k.tasa_participacion_pct}% tasa`);
+      $('#kpi-riesgo') && ($('#kpi-riesgo').textContent = k.riesgo_global_aprox);
+      $('#kpi-riesgo-pill') && ($('#kpi-riesgo-pill').className = 'pill ' + (k.riesgo_global_aprox === 'Bajo' ? 'ok' : 'warn'));
+      $('#kpi-casos') && ($('#kpi-casos').textContent = fmt(k.casos_abiertos));
+      $('#kpi-casos-pill') && ($('#kpi-casos-pill').textContent = k.casos_abiertos >= 3 ? '3 urgentes' : 'OK');
+      $('#kpi-casos-pill') && ($('#kpi-casos-pill').className = 'pill ' + (k.casos_abiertos >= 3 ? 'danger' : 'ok'));
+    } catch (e) {
+      console.error(e);
+    }
   }
 
   // EVALUACIONES
   if (hash === '#/evaluaciones') {
-    const tbody = $("#tbl-evaluaciones-body");
-    if (tbody) {
-      tbody.innerHTML = data.evaluaciones.map(ev => `
+    const tbody = $('#tbl-evaluaciones-body');
+    try {
+      const list = await Api.evaluaciones_list();
+      tbody.innerHTML = list.map(ev => `
         <tr data-id="${ev.id}">
           <td>${ev.instrumento}</td>
           <td>${ev.area}</td>
-          <td>${fmt(formatPeriodo(ev.periodo))}</td>
-          <td><span class="pill ${ev.estado === "Completado" ? "ok" : "warn"}">${ev.estado}</span></td>
-          <td>${ev.respuestas}/${ev.total}</td>
+          <td>${formatPeriodoFromDate(ev.periodo)}</td>
+          <td><span class="pill ${ev.estado === 'Completado' ? 'ok' : 'warn'}">${ev.estado}</span></td>
+          <td>${ev.respondieron}/${ev.total_trab}</td>
           <td>
             <button class="btn btn-mini" data-act="ver">Ver</button>
             <button class="btn btn-mini" data-act="pdf">PDF</button>
@@ -148,64 +136,68 @@ function initPerView(hash) {
             <button class="btn btn-mini" data-act="del">🗑</button>
           </td>
         </tr>
-      `).join("");
-    }
+      `).join('');
 
-    // Crear nueva evaluación (form modal del topbar)
-    const btnCrear = $("#btn-nueva-eval");
-    btnCrear && (btnCrear.onclick = () => openModal("Nueva evaluación"));
+      // Acciones por fila
+      tbody.addEventListener('click', async (e)=>{
+        const btn = e.target.closest('button[data-act]');
+        if (!btn) return;
+        const tr = e.target.closest('tr');
+        const id = tr?.dataset.id;
+        const act = btn.dataset.act;
 
-    // Acciones por fila
-    tbody?.addEventListener("click", (e)=>{
-      const btn = e.target.closest("button[data-act]");
-      if (!btn) return;
-      const tr = e.target.closest("tr");
-      const id = tr?.dataset.id;
-      const act = btn.dataset.act;
-
-      if (act === "del") {
-        if (confirm("¿Eliminar evaluación?")) {
-          Store.eval_remove(id);
-          loadView();
+        if (act === 'del') {
+          if (confirm('¿Eliminar evaluación?')) {
+            await Api.evaluaciones_delete(id);
+            await loadView();
+          }
         }
-      }
-      if (act === "fin") {
-        Store.eval_update(id, { estado: "Completado" });
-        loadView();
-      }
-      if (act === "ver") alert("Ver resultados (Demo)");
-      if (act === "pdf") alert("Generar PDF (Demo)");
-    });
+        if (act === 'fin') {
+          await Api.evaluaciones_finalizar(id);
+          await loadView();
+        }
+        if (act === 'ver') alert('Ver resultados (implementa tu vista)');
+        if (act === 'pdf') alert('Generar/descargar PDF (implementa tu endpoint)');
+      });
 
-    // Form inline de creación
-    const form = $("#form-eval");
-    form?.addEventListener("submit", (e)=>{
-      e.preventDefault();
-      const f = e.target;
-      const instrumento = f.instrumento.value;
-      const area = f.area.value.trim();
-      const periodo = f.periodo.value;
-      const total = parseInt(f.total.value || "0", 10);
+      // Crear desde el form de la toolbar
+      const form = $('#form-eval');
+      form?.addEventListener('submit', async (e)=>{
+        e.preventDefault();
+        const f = e.target;
+        const instrumento = f.instrumento.value;
+        const area = f.area.value.trim();
+        const periodo = f.periodo.value;              // yyyy-mm
+        const total_trab = parseInt(f.total.value||'0',10);
 
-      if (!instrumento || !area || !periodo) return alert("Completa los campos requeridos");
-      Store.eval_add({ instrumento, area, periodo, total, respuestas: 0 });
-      e.target.reset();
-      loadView();
-    });
+        if (!instrumento || !area || !periodo) return alert('Completa los campos');
+        // Por ahora asumimos 1 tenant (el primero de KPIs)
+        const kpis = await Api.kpis();
+        const tenant_id = (kpis[0] && kpis[0].tenant_id) || null;
+        if (!tenant_id) return alert('No hay tenant en BD');
+
+        await Api.evaluaciones_create({ tenant_id, instrumento, area, periodo, total_trab });
+        f.reset();
+        await loadView();
+      });
+    } catch (e) {
+      console.error(e);
+      tbody.innerHTML = `<tr><td colspan="6">Error cargando evaluaciones</td></tr>`;
+    }
   }
 
-  // REPORTES (tabs demo) — se mantiene igual
+  // REPORTES (tabs demo sin backend aún)
   if (hash === '#/reportes') {
-    const tabs = $("#tabs-reportes");
+    const tabs = $('#tabs-reportes');
     const panels = {
-      global: $("#panel-global"),
-      individuales: $("#panel-individuales"),
-      comparativos: $("#panel-comparativos"),
+      global: $('#panel-global'),
+      individuales: $('#panel-individuales'),
+      comparativos: $('#panel-comparativos'),
     };
     tabs?.addEventListener('click', (e)=>{
       const btn = e.target.closest('.tab');
       if (!btn) return;
-      $$(".tab", tabs).forEach(t=>t.classList.remove('active'));
+      $$('.tab', tabs).forEach(t=>t.classList.remove('active'));
       btn.classList.add('active');
       const tab = btn.dataset.tab;
       Object.keys(panels).forEach(k => panels[k].style.display = (k===tab?'block':'none'));
@@ -213,20 +205,16 @@ function initPerView(hash) {
   }
 }
 
-/* ---------------------
-   Helpers
-----------------------*/
-function formatPeriodo(yyyyMM) {
-  // yyyy-mm (input de tipo month) → "Oct-2025"
-  if (!yyyyMM) return "";
-  const [y,m] = yyyyMM.split("-");
-  const meses = ["Ene","Feb","Mar","Abr","May","Jun","Jul","Ago","Sep","Oct","Nov","Dic"];
-  return `${meses[(+m||1)-1]}-${y}`;
+/* -------- Helpers -------- */
+function formatPeriodoFromDate(dateStr) {
+  // "2025-10-01" → "Oct-2025"
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  const meses = ['Ene','Feb','Mar','Abr','May','Jun','Jul','Ago','Sep','Oct','Nov','Dic'];
+  return `${meses[d.getUTCMonth()]}-${d.getUTCFullYear()}`;
 }
 
-/* ---------------------
-   Modal genérico
-----------------------*/
+/* -------- Modal genérico (igual) -------- */
 const modalBg = document.getElementById('modal-bg');
 const openModal = (title='Nueva evaluación')=>{
   document.getElementById('modal-title').textContent = title;
@@ -240,30 +228,13 @@ const closeModal = ()=>{
 document.getElementById('modal-close').onclick = closeModal;
 document.getElementById('modal-cancel').onclick = closeModal;
 
-/* ---------------------
-   Topbar / acciones
-----------------------*/
+/* -------- Topbar -------- */
 document.getElementById('btnNew').onclick = ()=> openModal('Nueva evaluación');
-document.getElementById('btnZip').onclick = ()=> alert('Generar Carpeta SUNAFIL (ZIP)… (Demo)');
-// Búsqueda (demo)
+document.getElementById('btnZip').onclick = ()=> alert('Generar Carpeta SUNAFIL (ZIP) — implementa /api/zip cuando quieras');
 document.getElementById('q').addEventListener('keydown', (e)=>{
-  if (e.key === 'Enter') alert('Buscar: ' + e.target.value + ' (Demo)');
+  if (e.key === 'Enter') alert('Buscar: ' + e.target.value + ' (pendiente implementar)');
 });
 
-/* ---------------------
-   Router listeners
-----------------------*/
+/* -------- Router -------- */
 window.addEventListener('hashchange', loadView);
-window.addEventListener('DOMContentLoaded', () => {
-  Store.load();
-  loadView();
-});
-
-
-// Dónde reemplazar más adelante:
-
-// Store (LocalStorage) → 🔁 REEMPLAZAR POR API REAL llamando fetch('/api/evaluaciones'), etc.
-
-// En eval_add, eval_update, eval_remove cambia a POST/PUT/DELETE.
-
-// En initPerView('#/evaluaciones') las acciones ver/pdf pueden ir a tus endpoints de generación de PDF y consulta de resultados.
+window.addEventListener('DOMContentLoaded', loadView);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "psicosst-app",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node server/index.js",
+    "start": "NODE_ENV=production node server/index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "pg": "^8.12.0"
+  }
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="postgresql://usuario:password@host.neon.tech:5432/db?sslmode=require"
+PORT=3000

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,18 @@
+import 'dotenv/config';
+import pkg from 'pg';
+const { Pool } = pkg;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL
+  // Neon ya requiere SSL con la URL si usas sslmode=require
+});
+
+export async function query(sql, params = []) {
+  const client = await pool.connect();
+  try {
+    const res = await client.query(sql, params);
+    return res;
+  } finally {
+    client.release();
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,143 @@
+import 'dotenv/config';
+import express from 'express';
+import cors from 'cors';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { query } from './db.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// Servir el front (archivos estáticos desde la raíz del proyecto)
+app.use(express.static(path.join(__dirname, '..')));
+
+/* ------------------------------
+   ENDPOINTS PRINCIPALES
+------------------------------ */
+
+// KPIs Dashboard
+app.get('/api/kpis', async (_req, res) => {
+  try {
+    const { rows } = await query('SELECT * FROM app.v_dashboard_kpis ORDER BY tenant_nombre LIMIT 50;');
+    res.json(rows);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'Error obteniendo KPIs' });
+  }
+});
+
+// Evaluaciones - resumen
+app.get('/api/evaluaciones', async (_req, res) => {
+  try {
+    const { rows } = await query(`
+      SELECT id, tenant_id, area, periodo, estado, total_trab, instrumento, respondieron
+      FROM app.v_evaluaciones_resumen
+      ORDER BY periodo DESC, area ASC;
+    `);
+    res.json(rows);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'Error listando evaluaciones' });
+  }
+});
+
+// Crear evaluación
+app.post('/api/evaluaciones', async (req, res) => {
+  try {
+    const { tenant_id, instrumento, area, periodo, total_trab } = req.body;
+
+    // Buscar instrumento_id por nombre
+    const ins = await query(
+      `SELECT id FROM app.instrumentos WHERE tenant_id = $1 AND nombre = $2 LIMIT 1;`,
+      [tenant_id, instrumento]
+    );
+    if (ins.rowCount === 0) return res.status(400).json({ error: 'Instrumento no encontrado' });
+
+    const instrumento_id = ins.rows[0].id;
+
+    const { rows } = await query(
+      `INSERT INTO app.evaluaciones (tenant_id, instrumento_id, area, periodo, total_trab, estado)
+       VALUES ($1, $2, $3, $4, $5, 'En curso')
+       RETURNING id;`,
+      [tenant_id, instrumento_id, area, periodo + '-01', total_trab || 0]
+    );
+    res.status(201).json({ id: rows[0].id });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'Error creando evaluación' });
+  }
+});
+
+// Finalizar evaluación
+app.put('/api/evaluaciones/:id/finalizar', async (req, res) => {
+  try {
+    await query(`UPDATE app.evaluaciones SET estado = 'Completado' WHERE id = $1;`, [req.params.id]);
+    res.json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'Error actualizando evaluación' });
+  }
+});
+
+// Eliminar evaluación
+app.delete('/api/evaluaciones/:id', async (req, res) => {
+  try {
+    await query(`DELETE FROM app.evaluaciones WHERE id = $1;`, [req.params.id]);
+    res.json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'Error eliminando evaluación' });
+  }
+});
+
+/* --------- Acciones (Plan) mínimas ---------- */
+
+// Listar acciones pendientes
+app.get('/api/acciones', async (_req, res) => {
+  try {
+    const { rows } = await query(`SELECT * FROM app.v_acciones_pendientes ORDER BY vence NULLS LAST;`);
+    res.json(rows);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'Error listando acciones' });
+  }
+});
+
+// Crear acción
+app.post('/api/acciones', async (req, res) => {
+  try {
+    const { tenant_id, evaluacion_id, riesgo, accion, responsable, vence } = req.body;
+    const { rows } = await query(
+      `INSERT INTO app.acciones (tenant_id, evaluacion_id, riesgo, accion, responsable, vence)
+       VALUES ($1,$2,$3,$4,$5,$6) RETURNING id;`,
+      [tenant_id, evaluacion_id || null, riesgo, accion, responsable || null, vence || null]
+    );
+    res.status(201).json({ id: rows[0].id });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'Error creando acción' });
+  }
+});
+
+// Actualizar estado de acción
+app.put('/api/acciones/:id', async (req, res) => {
+  try {
+    const { estado } = req.body; // 'Pendiente' | 'En curso' | 'Completada'
+    await query(`UPDATE app.acciones SET estado = $1 WHERE id = $2;`, [estado, req.params.id]);
+    res.json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'Error actualizando acción' });
+  }
+});
+
+/* ------------------------------------------ */
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`✅ API corriendo en http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add an Express server that serves the SPA and exposes endpoints for KPIs, evaluations, and actions backed by Neon Postgres
- configure database utility and environment template for the new backend
- replace the frontend store with an API client and add project metadata along with ignores for local secrets

## Testing
- npm i *(fails in container: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a22d7b9483339bc44eceff5882f7