### PR TITLE
Add database connection example and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # PsicoSSTCloud
+
+## Configuración rápida
+
+1. Instala las dependencias:
+   ```bash
+   npm install
+   ```
+2. Copia el archivo de variables de entorno de ejemplo y actualiza los datos si fuera necesario:
+   ```bash
+   cp server/.env.example server/.env
+   ```
+3. Inicia el servidor de desarrollo:
+   ```bash
+   npm run dev
+   ```
+
+## Variables de entorno
+
+La API usa `pg` para conectarse a la base de datos. Define la variable `DATABASE_URL` en `server/.env` con el string de conexión que entrega tu proveedor. Por ejemplo:
+
+```env
+DATABASE_URL="postgresql://neondb_owner:npg_qrXE48eofWVC@ep-divine-shadow-adp4gjr5-pooler.c-2.us-east-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require"
+```
+
+El proyecto ya está preparado para cargar automáticamente estas variables mediante `dotenv`.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,2 +1,3 @@
-DATABASE_URL="postgresql://usuario:password@host.neon.tech:5432/db?sslmode=require"
-PORT=3000
+# Example environment configuration for the backend server
+# Copy this file to .env and adjust the values as needed.
+DATABASE_URL="postgresql://neondb_owner:npg_qrXE48eofWVC@ep-divine-shadow-adp4gjr5-pooler.c-2.us-east-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require"


### PR DESCRIPTION
## Summary
- add an example environment file that includes the Neon connection string required by the backend
- document the quick-start setup steps and how to configure the DATABASE_URL in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5a9911dbc833385d9d8b1c6cceb41